### PR TITLE
[Feature/SAN-182] context api 적용

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import PushNotification from "../component/PushNotification";
 import {useEffect} from "react";
 import {useRouter} from "next/router";
 import * as ga from '../lib/gtag';
+import Store from "../store/store";
 
 declare global {
   interface Window {
@@ -27,10 +28,12 @@ function MyApp({ Component, pageProps }: AppProps) {
     }, [router.events]);
 
   return (
-    <Layout>
-      <PushNotification />
-      <Component {...pageProps} />
-    </Layout>
+    <Store>
+      <Layout>
+        <PushNotification />
+        <Component {...pageProps} />
+      </Layout>
+    </Store>
   );
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import Calendar from "../component/index/Calendar";
 import Share, { RedBtn } from "../component/share/Share";
 import { getCookie } from "../businesslogics/cookie";
 import ReactHowler from "react-howler";
-import { lazy, useEffect, useState } from "react";
+import { lazy, useContext, useEffect, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import FriendsModal from "../component/friends/FriendsModal";
 import { Suspense } from "react";
@@ -16,6 +16,7 @@ import { useRouter } from "next/router";
 import { setBGM } from "../api/hooks/useStting";
 import { getLoggedMember } from "../api/hooks/useMember";
 import InformationModal from "../component/index/InformationModal";
+import { storeContext } from "../store/store";
 
 const MainIcons = styled(Icons)`
   height: 35px;
@@ -65,7 +66,8 @@ const SnowballContainer = styled(MainContainer)`
   }
 `;
 const Home: NextPage = () => {
-  const router = useRouter();
+  const router = useRouter()
+  const { storeUserData, updateUserData } = useContext(storeContext);
   const [memberInfo, setMemberInfo] = useState<MemberData>();
 
   const [myBGM, setMyBGM] = useState<any>(null);
@@ -120,9 +122,15 @@ const Home: NextPage = () => {
     const res = await setGetMember();
     setMemberInfo(res);
   };
+  const storeMemberData = async () => {
+    const userData = await updateUserData();
+    setMemberInfo(userData);
+  }
   useEffect(() => {
-    getMemberData();
+    // getMemberData();
+    storeMemberData();
   }, []);
+
   const currInvitationLink = router.pathname; // 현재 invitation link
   // const ismycalendar =
   //   memberInfo && currInvitationLink === memberInfo.invitationLink;
@@ -160,6 +168,8 @@ const Home: NextPage = () => {
       </>
     );
   };
+
+  console.log(storeUserData);
 
   const handleGoMyCal = () => {
     router.push(`/${memberInfo.invitationLink}`);

--- a/store/Store.tsx
+++ b/store/Store.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useState } from 'react';
+import { getLoggedMember } from '../api/hooks/useMember';
+import { defaultMemberData, MemberData } from '../util/type';
+
+const initialValue: valueType = {
+  storeUserData: defaultMemberData,
+  updateUserData: () => {},
+};
+
+export const storeContext = createContext(initialValue);
+
+export default function Store({ children }: Props) {
+  const [storeUserData, setStoreUserdata] = useState<MemberData>({} as MemberData);
+
+  const updateUserData = async () => {
+    const data = await getLoggedMember();
+    setStoreUserdata(data.data);
+    return data.data;
+  };
+
+  const value = {
+    storeUserData,
+    updateUserData,
+  };
+
+  return (
+    <storeContext.Provider value={value}>{children}</storeContext.Provider>
+  );
+}
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface valueType {
+  storeUserData: MemberData;
+  updateUserData: any;
+}

--- a/util/type.ts
+++ b/util/type.ts
@@ -36,6 +36,20 @@ export interface PutMemberData{
   statusMessage: string;
 }
 
+export const defaultMemberData = {
+  id: '',
+  nickname: '',
+  profileImageURL: '',
+  email: '',
+  invitationLink: '',
+  setting : {
+    id: -1,
+    isAlert: false,
+    bgm: false,
+    fcmtokens: '',
+  }
+}
+
 // Friends types ------------------------------------
 export interface FriendsData {
   id: number;


### PR DESCRIPTION
## 작업 프로젝트 링크
- [SAN-182 | context api 적용](https://saboten.atlassian.net/browse/SAN-182)

## 작업한 내용
- [x] context api 적용

 비고
- context api 적용 방법
- 현재 index에 memberInfo를 컨텍스트에서 가져오도록 수정해놓았습니다. (원 코드 주석처리)
- const { storeUserData, updateUserData } = useContext(storeContext); 처럼 불러와 사용할 수  있으며 updateUserData는 스토어 내부에서 통신하여 스토어의 storeUserData를 업데이트하는 함수입니다. 멤버를 갱신할 때 따로 api 사용할 필요 없이 updateUserData를 호출해주시면 됩니다. updateUserData는 현재 로그인된 유저의 정보를 불러오는 api를 사용중입니다.
