### PR TITLE
[Feature/SAN-199] 로그인로직 수정중

### DIFF
--- a/api/APIInstance.ts
+++ b/api/APIInstance.ts
@@ -2,7 +2,8 @@ import axios from "axios";
 import {getCookie} from "../businesslogics/reactCookie";
 
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+// const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+const BASE_URL = "https://pitapat-adventcalendar.shop"
 
 const loadAccessToken = () => {  //여기서 getCookie로 토큰을 가져와서 만약 없으면 로그인링크로 푸시 / 있으면 로그인도있구나 판단 후 정상연결
   return getCookie('token');

--- a/api/AuthService.ts
+++ b/api/AuthService.ts
@@ -1,11 +1,9 @@
 import {  AuthInstance } from "./APIInstance";
-import {getCookie} from "../businesslogics/cookie";
-import {useEffect, useState} from "react";
 
 class AuthService {
     //백엔드에 인가코드주고 Jwt 받아오기
     getKakaoLogin= (code, state) => {
-        const link = `http://pitapat-adventcalendar.shop:8080/oauth/callback/kakao?code=${code}&state=${state}`
+        const link = `https://pitapat-adventcalendar.shop/oauth/callback/kakao?code=${code}&state=${state}`
         return AuthInstance.get<any>(link)
     }
 }

--- a/api/hooks/useKakaoLogin.ts
+++ b/api/hooks/useKakaoLogin.ts
@@ -1,5 +1,5 @@
 import AuthService from "../AuthService";
-import { removeCookie, setCookie } from "../../businesslogics/cookie";
+import {removeCookie} from "../../businesslogics/cookie";
 import {AuthAuthInstance} from "../APIInstance";
 import {ResponseData} from "../../util/type";
 
@@ -12,15 +12,12 @@ export const kakaoLogout = () => {
 //엑세스토큰 받아오는 url
 export async function KakaoLogin(code, state) {
   try {
-    const res = await AuthService.getKakaoLogin(code, state);
     // console.log("쿠키굽기 #################");
-    // console.log(res);
-    setCookie("token", res.data.data.token, 30);
-    setCookie('subToken', res.data.data.refreshToken,30);
-    return res;
+    // // console.log(res);
+    // await setCookie("token", res.data.data.token, 30);
+    // await setCookie('subToken', res.data.data.refreshToken,30);
+    return await AuthService.getKakaoLogin(code, state);
   } catch (e) {
       return e;
-    console.log("쿠키굽기 실패");
-    console.log(e);
   }
 }

--- a/component/tab/ReceivedPresentList.tsx
+++ b/component/tab/ReceivedPresentList.tsx
@@ -33,10 +33,15 @@ const ReceivedPresentList = () => {
     const initReceivedPresentList = async () => {
       try {
         const res = await PresentService.getLoggedUserPresentList();
+        console.log("두어캔에 오신걸 환영합니다✨")
+        console.log(res)
         setReceivedPresentList(res.data.data.content);
       }catch (e){
-        alert("로그인이 필요합니다✨")
-        router.push('/login')
+        // alert(e)
+        // console.log(">>>>>>>너였구나")
+        console.log(e)
+        alert("두어캔에 오신걸 환영합니다✨")
+        router.push('/')
       }
 
     };

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -34,8 +34,8 @@ const Login: NextPage = () => {
           하얀코와 함께
           <br /> 어드벤트 캘린더를 모으러 가볼까요?
         </h3>
-        {/* <Link href={"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3c01bf310ee0268b13dab1daa6c3a78a&scope=account_email%20profile_nickname%20profile_image%20friends&state=ZG_0J4yTF5EXpiZdBZhoTUNkRyyeclSFvLjlJAe20_g%3D&redirect_uri=http://localhost:3000/oauth/callback/kakao"}> */}
-        <Link href={"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3c01bf310ee0268b13dab1daa6c3a78a&scope=account_email%20profile_nickname%20profile_image%20friends&state=ZG_0J4yTF5EXpiZdBZhoTUNkRyyeclSFvLjlJAe20_g%3D&redirect_uri=http://pitapat-adventcalendar.site:3000/oauth/callback/kakao"}>
+         {/*<Link href={"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3c01bf310ee0268b13dab1daa6c3a78a&scope=account_email%20profile_nickname%20profile_image%20friends&state=ZG_0J4yTF5EXpiZdBZhoTUNkRyyeclSFvLjlJAe20_g%3D&redirect_uri=http://localhost:3000/oauth/callback/kakao"}>*/}
+        <Link href={"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3c01bf310ee0268b13dab1daa6c3a78a&scope=account_email%20profile_nickname%20profile_image%20friends&state=ZG_0J4yTF5EXpiZdBZhoTUNkRyyeclSFvLjlJAe20_g%3D&redirect_uri=https://pitapat-adventcalendar.site/oauth/callback/kakao"}>
           <img src="/assets/image/kakao_login_large_narrow.png" width="222" />
         </Link>
       </Container>

--- a/pages/oauth/callback/kakao.tsx
+++ b/pages/oauth/callback/kakao.tsx
@@ -13,13 +13,15 @@ const Kakao : NextPage = () => {
     const [isLogin, setIsLogin] = useState(false);
     const {updateRefreshToken} = useContext(storeContext);
 
-    //로그인하는 함수
+    //로그인하는 함수(인가코드 받아와 백엔드에서 두 Token을 받아옴)
     const run = async () => {
         try {
             const res = await KakaoLogin(new URL(window.location.href).searchParams.get("code"), new URL(window.location.href).searchParams.get("state"));
-            setRefresh(res.data.data.refreshToken);
-            setIsLogin(true);
-            
+            await setCookie("token", res.data.data.token, 30);
+            await setCookie('subToken', res.data.data.refreshToken,30);
+            // setRefresh(res.data.data.refreshToken);
+            // setIsLogin(true);
+
             // getUserData
             const loggedMember = await getLoggedMember();
             setCookie('invitationLink', loggedMember.invitationLink, 30);


### PR DESCRIPTION
## 작업 프로젝트 링크
- [SAN-199 | 로그인로직 수정중](https://saboten.atlassian.net/browse/SAN-199)

## 작업한 내용
- [x] 로그인로직 수정
- [x] baseURL 변경, http -> https로 URL 변경

 비고
- 각 단계별 URL http -> https로 URL 변경 (확인예정)

### 1. 로그인 버튼 링크(카카오 인가코드 요청)

```jsx
//login.tsx, lougout.tsx

<Link href={"https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=3c01bf310ee0268b13dab1daa6c3a78a
&scope=account_email%20profile_nickname%20profile_image%20friends&state=ZG_0J4yTF5EXpiZdBZhoTUNkRyyeclSFvLjlJAe20_g%3D&
redirect_uri=https://pitapat-adventcalendar.site/oauth/callback/kakao"}>
```

### 2. 인가코드(code) 받기

```jsx
// oauth/callback/kakao.tsx
const res = await KakaoLogin(new URL(window.location.href).searchParams.get("code"),
 new URL(window.location.href).searchParams.get("state"));
```

### 3. code를 백엔드에 인가코드 주고 Access, Refresh Token 받아오기

```jsx
//AuthService.ts
const link = `https://pitapat-adventcalendar.shop/oauth/callback/kakao?
code=${code}&state=${state}`
```

### 4. 받아온 토큰 쿠키에 넣기