### PR TITLE
[Hotfix/logout] 로그아웃 로직 수정 및 강화

### DIFF
--- a/businesslogics/cookie.ts
+++ b/businesslogics/cookie.ts
@@ -25,5 +25,5 @@ export const setCookie = (name, value, days = null) => {
 };
 
 export const removeCookie = (name : string) => {
-  document.cookie = name +'=; path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+  document.cookie = name +`=; path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT; domain=${document.location.hostname};`;
 };

--- a/component/layout/Header.tsx
+++ b/component/layout/Header.tsx
@@ -91,7 +91,8 @@ const Header = () => {
       {currPath === "onboarding" ? (
         <></>
       ) : currPath === "logout" ? <></> :
-          currPath === "login" ? <></> :(
+          currPath === "login" ? <></> :
+        currPath === "title" ? <></> : (
         <>
           <Flex>
             <Logo

--- a/component/mypage/Sidebar.tsx
+++ b/component/mypage/Sidebar.tsx
@@ -150,7 +150,6 @@ const Sidebar = (props) => {
               <Img src="/assets/image/character/face_heart_white.png" />
               <Index
                 onClick={() => {
-                  setCookie("token",'',30);
                   if (kakaoLogout() === "logout_ok") router.push("/logout");
                 }}
               >

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -17,7 +17,7 @@ const Custom404 = () => {
         <br />
         앗... 길을 잘못 들었다..
       </h3>
-      <h2>이 마을엔 아무도 안 살고 잇따!</h2>
+      <h2>내가 &apos;잘못된 친구코드&apos; 를 가져왔구나!</h2>
       <img src="/assets/image/404.png" width="200" />
     </Container>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -106,15 +106,10 @@ const Home: NextPage<dataProps> = (props: dataProps) => {
     }
   };
 
-  useEffect(() => {
-    getMyBGM();
-  }, []);
-
   const muteHandler = (value) => {
     setMute(!value);
     setBGM(!value);
   }
-
 
   const linkCopyHandler = async () => {
     const copyURL = `https://pitapat-adventcalendar.site/${myLink}`;
@@ -154,7 +149,6 @@ const Home: NextPage<dataProps> = (props: dataProps) => {
     setSnawballModalShow(!snowballModalShow);
   };
 
-
   const getCurrCalUser = async () => {
     let currInvitationLink = props.link
     try {
@@ -167,18 +161,7 @@ const Home: NextPage<dataProps> = (props: dataProps) => {
       // setMyName(router.asPath.slice(1))
     }
   };
-  // cookie
-  useEffect(() => {
-    const onboardingCookie = getCookie("onboarding");
-    if (onboardingCookie === "" && props.data) {
-      router.push("/onboarding");
-    }
-    if (onboardingCookie && !isLogged && props.data) {
-      // 온보딩봤고, 로그인안했고, 친구코드로 접속한게 아니면 login으로
-      // 친구코드가 있으면 그 친구코드정보로 index를 뿌려줘야하기 때문임
-      router.push("/login");
-    }
-  }, []);
+
 
 const [isLogged, setIsLogged] = useState(true);
   // 사용자의 정보를 조회해 캘린더의 접근 권한을 설정한다.
@@ -195,6 +178,28 @@ const [isLogged, setIsLogged] = useState(true);
       // console.log(e);
     }
   };
+
+  // cookie
+  const checkLocation = () =>{
+    const onboardingCookie = getCookie("onboarding");
+    console.log(">>>>>>>>is")
+    console.log(getCookie('token')=="")
+    console.log(isLogged)
+    console.log(onboardingCookie)
+    if (onboardingCookie === "" && props.data == undefined) {
+      router.push("/onboarding");
+    }
+    if (onboardingCookie && getCookie('token') == "" && props.data === undefined) {
+      // 온보딩봤고, 로그인안했고, 친구코드로 접속한게 아니면 login으로
+      // 친구코드가 있으면 그 친구코드정보로 index를 뿌려줘야하기 때문임
+      router.push("/title");
+    }
+  }
+
+  useEffect(() => {
+    getMyBGM();
+    checkLocation();
+  }, []);
 
   useEffect(() => {
     getMemberData();

--- a/pages/logout.tsx
+++ b/pages/logout.tsx
@@ -4,6 +4,8 @@ import { MainContainer } from "../styles/styledComponentModule";
 import styled from "styled-components";
 import {useEffect} from "react";
 import {removeCookie} from "../businesslogics/cookie";
+import {useRouter} from "next/router";
+
 
 const Container = styled(MainContainer)`
   text-align: center;
@@ -13,9 +15,19 @@ const Container = styled(MainContainer)`
 `;
 
 const Logout: NextPage = () => {
-    useEffect(()=>{
+    const router = useRouter();
+    useEffect(() => {
+        const preventGoBack = () => {
+            history.go(1);
+            router.push('/title')
+            console.log('prevent go back!');
+        };
+
+        history.pushState(null, '', location.href);
+        window.addEventListener('popstate', preventGoBack);
         removeCookie('token');
-    },[])
+        return () => window.removeEventListener('popstate', preventGoBack);
+    }, []);
   return (
     <Container>
       <img src="/assets/image/character/face_sad.png" width="222" />

--- a/pages/logout.tsx
+++ b/pages/logout.tsx
@@ -4,7 +4,6 @@ import { MainContainer } from "../styles/styledComponentModule";
 import styled from "styled-components";
 import {useEffect} from "react";
 import {removeCookie} from "../businesslogics/cookie";
-import {setCookie} from "cookies-next";
 
 const Container = styled(MainContainer)`
   text-align: center;
@@ -16,7 +15,6 @@ const Container = styled(MainContainer)`
 const Logout: NextPage = () => {
     useEffect(()=>{
         removeCookie('token');
-        setCookie('token', '')
     },[])
   return (
     <Container>

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -50,9 +50,11 @@ const MyPage: NextPage = () => {
       setMyEmail(res.email);
       setMyProfileImg(res.profileImageURL);
     } catch (e) {
+        router.push('/title')
       // console.log(e);
     }
   };
+
 
   useEffect(() => {
     getUserData();

--- a/pages/title.tsx
+++ b/pages/title.tsx
@@ -1,0 +1,80 @@
+import {useRouter} from "next/router";
+import styled from "styled-components";
+import {useEffect, useState} from "react";
+import {getCookie} from "../businesslogics/cookie";
+
+const GoBtn = styled.button`
+  background: #ac473d;
+  border-radius: 12px;
+  width: 312px;
+  height: 72px;
+
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 100%;
+  color: #f0ede2;
+
+  border: 0;
+`;
+const Div = styled.div`
+  text-align: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 50px;
+`
+const Image = styled.img`
+  display: block;
+  width: 300px;
+  margin: 0 auto 50px auto ;
+  @media (max-width: 600px) {
+    width: 230px;
+    margin: 0 auto 25px auto ;
+  }
+`;
+const StoryLink = styled.a`
+  text-decoration: none;
+  color: white;
+  width: 312px;
+  text-shadow: 0 0 5px #823e40;
+  font-size: 20px;
+  display: block;
+  margin-top: 10px;
+  background-color: rgba(130, 62, 64, 0.1);
+  border-radius: 10px;
+  padding: 2px 10px;
+  margin: 10px auto;
+  &:hover{  
+    color : white;
+    text-decoration: underline;
+  }
+`;
+const Title = () => {
+    const router = useRouter();
+    const [visited, setVisited] = useState(false);
+
+    useEffect(() => {
+        const token = getCookie("token");
+        if (token !== "") {
+            //방문한 적이 있으면
+            setVisited(true);
+        }
+    }, []);
+    return (
+            <Div>
+                <Image src="/assets/image/character/face_heart.png" />
+                <Image src="/assets/image/onboarding/title.png" />
+                {visited === true ? (
+                    <GoBtn onClick={() => (router.push("/") )}>
+                        내 캘린더로 가기
+                    </GoBtn>
+                ) : (
+                    <GoBtn onClick={() => (router.push("/login")) }>내 캘린더 만들러가기</GoBtn>
+                )}
+                <StoryLink href={`https://pitapat-adventcalendar.site/onboarding`}>
+                    👉 스토리 보러가기
+                </StoryLink>
+            </Div>
+    );
+}
+export default Title


### PR DESCRIPTION
## 작업한 내용
- [x] 로그아웃 로직 수정 및 강화
- [x] 쿠키 강화
- [x] 404 페이지 수정




 비고
--로그인안하고/하고 → 친구코드로 ⇒ 친구캘린더
- 로그인 안하고 → 내캘린더 ⇒ 타이틀로
- 로그인 안하고 → 마이페이지 ⇒ 로그인으로
- 로그아웃 → 마이페이지 => 로그인창으로 이동로
- 로그아웃 후 뒤로가기 ⇒ 타이틀로
- 로그인하고 ⇒ 내캘린더
- 그냥아얘 처음 → 온보딩
