### PR TITLE
초대링크로 멤버 조회 api -> friendsdata가 아닌 memberdata로 수정

### DIFF
--- a/api/FriendsService.ts
+++ b/api/FriendsService.ts
@@ -18,17 +18,5 @@ class FriendsService {
       config
     );
   };
-
-  //링크로 친구 검색하기 (서버) 🔑
-  getServerUserInfo = (config, token) => {
-    const FriendsServerAuthInstance = AuthAPIInstance(
-      process.env.NEXT_PUBLIC_BASE_URL,
-      token
-    );
-    return FriendsServerAuthInstance.get<ResponseData<FriendsData>>(
-      `/api/friend/search`,
-      config
-    );
-  };
 }
 export default new FriendsService();

--- a/api/FriendsService.ts
+++ b/api/FriendsService.ts
@@ -1,5 +1,5 @@
 import { AuthAPIInstance, FriendsAuthInstance } from "./APIInstance";
-import { FriendsData, ResponseData } from "../util/type";
+import { FriendsData, MemberData, ResponseData } from "../util/type";
 
 class FriendsService {
   //친구 목록 API 🔑
@@ -13,7 +13,7 @@ class FriendsService {
 
   //링크로 친구 검색하기 🔑
   getFriend = (config) => {
-    return FriendsAuthInstance.get<ResponseData<FriendsData>>(
+    return FriendsAuthInstance.get<ResponseData<MemberData>>(
       `/api/friend/search`,
       config
     );

--- a/api/FriendsService.ts
+++ b/api/FriendsService.ts
@@ -1,4 +1,4 @@
-import { AuthAPIInstance, FriendsAuthInstance } from "./APIInstance";
+import { FriendsAuthInstance } from "./APIInstance";
 import { FriendsData, MemberData, ResponseData } from "../util/type";
 
 class FriendsService {

--- a/api/MemberService.ts
+++ b/api/MemberService.ts
@@ -1,8 +1,4 @@
-import {
-  AuthAPIInstance,
-  MemberAuthInstance,
-  MemberFileInstance,
-} from "./APIInstance";
+import { MemberAuthInstance, MemberFileInstance } from "./APIInstance";
 import {
   MemberData,
   MemberRawData,
@@ -15,17 +11,6 @@ class MemberService {
   //내정보 조회 🔑(마이페이지 조회)
   getLoggedMember = () =>
     MemberAuthInstance.get<ResponseData<MemberRawData>>(`/api/member`);
-
-  //내정보 조회 🔑 (서버 / 마이페이지 조회)
-  getServerLoggedMember = (token) => {
-    const MembeServerAuthInstance = AuthAPIInstance(
-      process.env.NEXT_PUBLIC_BASE_URL,
-      token
-    );
-    return MembeServerAuthInstance.get<ResponseData<MemberRawData>>(
-      `/api/member`
-    );
-  };
 
   //특정 유저정보 조회(익명이 특정 유저 검색)
   getMemberById = (config) =>

--- a/api/hooks/useGetCurrCalendarUserInfo.ts
+++ b/api/hooks/useGetCurrCalendarUserInfo.ts
@@ -8,20 +8,3 @@ export async function setGetCurrCalendarUserInfo(inviteLink) {
   };
   return await FriendsService.getFriend(config);
 }
-
-/**
- * invitationLink로 멤버 조회 (서버)
- */
-export async function getServerUserInfo(inviteLink, token) {
-  const config = {
-    params: {
-      link: inviteLink,
-    },
-  };
-  try {
-    const res = await FriendsService.getServerUserInfo(config, token);
-    return res;
-  } catch (e) {
-    console.log(e);
-  }
-}

--- a/api/hooks/useMember.ts
+++ b/api/hooks/useMember.ts
@@ -22,17 +22,6 @@ export async function getLoggedMemberRaw() {
   }
 }
 
-/**
- * 로그인한 유저 조회 (서버)
- */
-export async function getServerLoggedMember(token) {
-  try {
-    const res = await MemberService.getServerLoggedMember(token);
-    return res;
-  } catch (e) {
-    console.log(e);
-  }
-}
 // export async function usePutMemberInfo(
 //     nickname : string,
 //     profileImageURL: string,

--- a/components/sendPresents/SendPresents.tsx
+++ b/components/sendPresents/SendPresents.tsx
@@ -6,13 +6,11 @@ import {
   GreenCloseButton,
 } from "../../styles/styledComponentModule";
 import Form from "react-bootstrap/Form";
-import { FriendsData } from "../../util/type";
+import { MemberData } from "../../util/type";
 import { usePostPresent } from "../../api/hooks/usePostPresent";
 import { useRouter } from "next/router";
 import { setGetCurrCalendarUserInfo } from "../../api/hooks/useGetCurrCalendarUserInfo";
-import { getLoggedMember } from "../../api/hooks/useMember";
 import MemberService from "../../api/MemberService";
-import PushService from "../../api/PushService";
 import Image from "next/image";
 
 export const PresentHeader = styled.div`
@@ -31,17 +29,19 @@ export const TextArea = styled.div`
   font-family: "NanumSquareNeoOTF-Bd", KCC-Ganpan, sans-serif;
   text-align: center;
   color: white;
-  background-image: url('/asset_ver2/image/presents/present_background.png');
+  background-image: url("/asset_ver2/image/presents/present_background.png");
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
   margin-top: 1rem;
   height: 17rem;
   padding: 1rem 4rem;
-  @media (min-width: 768px) {//태블릿 대응
+  @media (min-width: 768px) {
+    //태블릿 대응
     padding: 1rem 6rem;
   }
-  @media (max-width: 300px) {//갤폴드 대응
+  @media (max-width: 300px) {
+    //갤폴드 대응
     padding: 3rem 1rem;
   }
 `;
@@ -68,7 +68,7 @@ const LoadingScreenBack = styled.div`
   left: 0;
   bottom: 0;
   right: 0;
-  background-color: #1E344F;
+  background-color: #1e344f;
   z-index: 10;
 `;
 
@@ -85,7 +85,7 @@ const SendPresents = ({ onHide, selectedday }) => {
   const [isAnonymous, setAnonymous] = useState<boolean | any>(false);
   const [nickname, setNickname] = useState<string>("익명의 산타");
   const [memberInfo, setMemberInfo] = useState<any>();
-  const [currCalUser, setCurrCalUser] = useState<FriendsData>();
+  const [currCalUser, setCurrCalUser] = useState<MemberData>();
   const [isLoading, setIsLoading] = useState(false);
   // ImageUpload -------------
   const [fileList, setFileList] = useState<File[]>([]);
@@ -303,8 +303,12 @@ const SendPresents = ({ onHide, selectedday }) => {
       </TextArea>
 
       <div className="Thumbnail_Wrapper">
-        {showImages.length === 0 ?
-          <label className="submitImg" htmlFor="file" onChange={handleAddImages}>
+        {showImages.length === 0 ? (
+          <label
+            className="submitImg"
+            htmlFor="file"
+            onChange={handleAddImages}
+          >
             <div className="addButton">
               <input
                 id="file"
@@ -314,7 +318,7 @@ const SendPresents = ({ onHide, selectedday }) => {
               />
             </div>
           </label>
-          :
+        ) : (
           <ThumbnailContainer>
             <label id="present_img" htmlFor="file" onChange={handleAddImages}>
               <input
@@ -325,8 +329,7 @@ const SendPresents = ({ onHide, selectedday }) => {
               />
             </label>
           </ThumbnailContainer>
-        }
-
+        )}
 
         <Flex>
           {showImages.map((image, id) => (
@@ -361,17 +364,22 @@ const SendPresents = ({ onHide, selectedday }) => {
         </JustifiedAlignedFlex>
         <GreenButton onClick={handleClickSendPresent}>
           쪽지보내기
-          <Image src={`/asset_ver2/image/send.png`} alt={"쪽지보내기"} width={13} height={13}/>
+          <Image
+            src={`/asset_ver2/image/send.png`}
+            alt={"쪽지보내기"}
+            width={13}
+            height={13}
+          />
         </GreenButton>
       </SubmitFlex>
-      {isLoading ?
+      {isLoading ? (
         <LoadingScreenBack>
           <LoadingContainer>
-            <img src="/assets/image/character/spinner.gif" alt="로딩하얀코"/>
+            <img src="/assets/image/character/spinner.gif" alt="로딩하얀코" />
             <p>선물을 보내는 중입니다...</p>
           </LoadingContainer>
         </LoadingScreenBack>
-        : null}
+      ) : null}
     </SendPresentsWrapper>
   );
 };


### PR DESCRIPTION
## 작업한 내용
- [x] [invitation_link].tsx
    - 초대링크로 멤버 조회 api -> friendsdata가 아닌 memberdata로 수정
    - 로그인하지 않은 사용자도 친구 캘린더 접근 자체는 가능하게 수정
- [x] 사용되지 않는 서버 api 삭제
    - 현재 사용중인 서버 api는 두두타 내글보기 기능뿐임
    - 해당 api 호출 시 토큰 없으면 요청하지 않고 빈 배열을 리턴하도록 처리함

저희 그동안 /api/friend/search api response를 friendsdata 타입으로 받아 사용하고 있었네요.. 어케했지 ㅋㅋㅋㅋㅋㅋ

 비고
- 
