### PR TITLE
feat: 메인 화면 share도 카카오 / url 모달로 변경

### DIFF
--- a/components/share/ShareLink.tsx
+++ b/components/share/ShareLink.tsx
@@ -1,33 +1,23 @@
 import Image from "next/image";
 import styled from "styled-components";
-import { loginUserDataAtom, modalStateAtom } from "../../store/globalState";
+import { modalStateAtom } from "../../store/globalState";
 import { useAtom } from "jotai";
 
 export const ShareLink = () => {
-  const [storeUserData] = useAtom(loginUserDataAtom);
   const [, setShowModal] = useAtom(modalStateAtom);
 
-  const linkCopyHandler = async () => {
-    const copyURL = `https://merry-christmas.site/${storeUserData.invitationLink}`;
-    try {
-      await navigator.clipboard.writeText(copyURL);
-      setShowModal({
-        label: "copy",
-        show: true,
-      });
-    } catch (e) {
-      alert(
-        "내 초대링크를 복사해 보내보세요! 바로 복사를 원하신다면~? 크롬브라우저로 접속해보세요✨"
-      );
-    }
-  };
   return (
     <ShareBtn
       src={`/asset_ver2/image/btn/link_btn.png`}
       width={44}
       height={44}
       alt={"링크복사버튼"}
-      onClick={linkCopyHandler}
+      onClick={() => {
+        setShowModal({
+          label: "share",
+          show: true,
+        });
+      }}
     />
   );
 };


### PR DESCRIPTION
## 작업한 내용
- [x] https://github.com/TeamSantas/front-santas/pull/281 에서 누락한 내용 추가합니다. (홈에 있는 링크도 카카오 / url share 모달 띄우도록 수정)

 비고
- 
